### PR TITLE
Suppress Chrome search engine choice screen for tests

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -107,7 +107,8 @@
               "@angular/material/prebuilt-themes/purple-green.css",
               "src/styles.scss"
             ],
-            "scripts": []
+            "scripts": [],
+            "karmaConfig": "karma.conf.js"
           }
         }
       }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -33,7 +33,13 @@ module.exports = function (config) {
       ]
     },
     reporters: ['progress', 'kjhtml'],
-    browsers: ['Chrome'],
+    browsers: ['ChromeWithoutNagScreen'],
+    customLaunchers: {
+      ChromeWithoutNagScreen: {
+        base: 'Chrome',
+        flags: ['--disable-search-engine-choice-screen']
+      }
+    },
     restartOnFileChange: true
   });
 };

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,39 @@
+// Karma configuration file, see link for more information
+// https://karma-runner.github.io/1.0/config/configuration-file.html
+
+module.exports = function (config) {
+  config.set({
+    basePath: '',
+    frameworks: ['jasmine', '@angular-devkit/build-angular'],
+    plugins: [
+      require('karma-jasmine'),
+      require('karma-chrome-launcher'),
+      require('karma-jasmine-html-reporter'),
+      require('karma-coverage'),
+      require('@angular-devkit/build-angular/plugins/karma')
+    ],
+    client: {
+      jasmine: {
+        // you can add configuration options for Jasmine here
+        // the possible options are listed at https://jasmine.github.io/api/edge/Configuration.html
+        // for example, you can disable the random execution with `random: false`
+        // or set a specific seed with `seed: 4321`
+      },
+      clearContext: false // leave Jasmine Spec Runner output visible in browser
+    },
+    jasmineHtmlReporter: {
+      suppressAll: true // removes the duplicated traces
+    },
+    coverageReporter: {
+      dir: require('path').join(__dirname, './coverage/efis-editor'),
+      subdir: '.',
+      reporters: [
+        { type: 'html' },
+        { type: 'text-summary' }
+      ]
+    },
+    reporters: ['progress', 'kjhtml'],
+    browsers: ['Chrome'],
+    restartOnFileChange: true
+  });
+};


### PR DESCRIPTION
So, I can't believe I'm the first person on the Internets to run into this, but apparently Europe plays such an important role in global software engineering trends that no one has noticed it yet \<g\>

Unfortunately, when I try to run the tests in Chrome, I'm always presented with the search engine selection screen. As soon as I manually make a selection and ask to save it as default, the tests run through. However, when the browser window is closed and restarted, the tests are blocked again until a manual selection is made.

Regardless of the debate about how many souls have been saved from Google's unfair market dominance by this screen, I think that at least in the context of testing, it's definitely counterproductive. Apparently it can be turned off, but it requires a full Karma config to do so. There seems to be no easy way to customize just the browser arguments from the command line. I hope the fix is correct and acceptable for us poor Germans to be able to run the tests again.

It seems that headless mode is not affected by this problem.