### PR TITLE
Allow basic keyboard navigation with tab, enter and esc

### DIFF
--- a/src/app/checklists/items-list/editable-label/editable-label.component.html
+++ b/src/app/checklists/items-list/editable-label/editable-label.component.html
@@ -3,7 +3,16 @@
 } @else {
   <mat-form-field appearance="outline" class="editable-input">
     <mat-label>{{ label }}</mat-label>
-    <input #promptInput matInput required type="text" [formControl]="control" (beforeinput)="onBeforeInput($event)" />
+    <input
+      #promptInput
+      matInput
+      required
+      type="text"
+      [formControl]="control"
+      (beforeinput)="onBeforeInput($event)"
+      (keyup.enter)="$event.stopPropagation(); value = promptInput.value; save()"
+      (keyup.escape)="$event.stopPropagation(); cancel()"
+    />
     <button
       mat-icon-button
       mat-medium-icon-button

--- a/src/app/checklists/items-list/editable-label/editable-label.component.ts
+++ b/src/app/checklists/items-list/editable-label/editable-label.component.ts
@@ -57,6 +57,16 @@ export class EditableLabelComponent {
     this.editing = true;
   }
 
+  focus() {
+    // setTimeout is needed to remove focusing from the execution stack and allow the input element to be created first
+    // See https://v17.angular.io/api/core/ViewChild for the details.
+    setTimeout(() => {
+      if (this.editing) {
+        this.input.nativeElement.focus();
+      }
+    });
+  }
+
   cancel() {
     if (this.editing) {
       this.editing = false;

--- a/src/app/checklists/items-list/item/item.component.html
+++ b/src/app/checklists/items-list/item/item.component.html
@@ -14,7 +14,7 @@
         matTooltip="Edit this line"
         [attr.aria-label]="'Edit ' + item.prompt"
         [disabled]="item.type === ChecklistItem_Type.ITEM_SPACE"
-        (click)="promptInput.edit(); expectationInput.edit()"
+        (click)="onEdit($event)"
       >
         <mat-icon fontIcon="edit" />
       </button>
@@ -64,7 +64,7 @@
         <mat-icon [fontIcon]="item.centered ? 'format_align_left' : 'format_align_center'" />
       </button>
     </div>
-    <div class="item" [class.item-centered]="item.centered">
+    <div class="item" [class.item-centered]="item.centered" tabindex="10" (keyup.enter)="onEdit($event)">
       <span
         class="prompt"
         [class.prompt-challenge]="item.type === ChecklistItem_Type.ITEM_CHALLENGE"

--- a/src/app/checklists/items-list/item/item.component.ts
+++ b/src/app/checklists/items-list/item/item.component.ts
@@ -32,6 +32,13 @@ export class ChecklistItemComponent {
 
   readonly ChecklistItem_Type = ChecklistItem_Type;
 
+  onEdit(e: Event) {
+    e.stopPropagation();
+    this.promptInput?.edit();
+    this.expectationInput?.edit();
+    this.promptInput?.focus();
+  }
+
   onIndent(item: ChecklistItem, delta: number) {
     item.indent += delta;
     this.onItemUpdated();

--- a/src/app/checklists/items-list/item/item.component.ts
+++ b/src/app/checklists/items-list/item/item.component.ts
@@ -34,9 +34,9 @@ export class ChecklistItemComponent {
 
   onEdit(e: Event) {
     e.stopPropagation();
-    this.promptInput?.edit();
-    this.expectationInput?.edit();
-    this.promptInput?.focus();
+    this.promptInput!.edit();
+    this.expectationInput!.edit();
+    this.promptInput!.focus();
   }
 
   onIndent(item: ChecklistItem, delta: number) {


### PR DESCRIPTION
As I started working on larger books, I found that the mouse-based workflow made it really difficult. So I've added very basic keyboard navigation for checklist items with minimal changes.

* Use Tab to move to the next checklist item
* Use Enter to edit the currently highlighted item
* Use Escape to abort editing and discard changes
* Use Enter to save changes

I was stunned by this, but the disgusting `setTimeout` seems to be a totally official approach when dealing with dynamic elements. The other recommended alternative seems to be to hide items instead. Not sure if there's a better way with some eventing magic, but if this is on the official Angular page, then probably not, or it's complicated.

I hope this is okay with you though.