### PR TITLE
docs(welcome): remove extra parens

### DIFF
--- a/src/app/welcome/welcome.component.html
+++ b/src/app/welcome/welcome.component.html
@@ -27,7 +27,7 @@
         <p>Currently supported import/export formats:</p>
         <ul>
           <li>Garmin G3X&trade;/GTN&trade; (.ace)</li>
-          <li>Dynon SkyView&trade; - multiple width options (.txt))</li>
+          <li>Dynon SkyView&trade; - multiple width options (.txt)</li>
           <li>Advanced Flight Systems (.afd)</li>
           <li>Grand Rapids Technology (.txt)</li>
           <li>Boeing ForeFlight (.{{ ForeFlightUtils.FILE_EXTENSION }})</li>


### PR DESCRIPTION
Just a trivial typo fix to avoid parsing errors in my head.