### PR TITLE
Supported formats refactoring

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
   "printWidth": 120,
-  "singleQuote": true
+  "singleQuote": true,
+  "plugins": ["prettier-plugin-organize-imports"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,6 +79,7 @@
         "pdfjs-dist": "^5.1.91",
         "prettier": "^3.5.3",
         "prettier-eslint": "^16.3.0",
+        "prettier-plugin-organize-imports": "^4.1.0",
         "typescript": "~5.8.3",
         "typescript-eslint": "8.29.0"
       }
@@ -14669,6 +14670,23 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/prettier-plugin-organize-imports": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-4.1.0.tgz",
+      "integrity": "sha512-5aWRdCgv645xaa58X8lOxzZoiHAldAPChljr/MT0crXVOWTZ+Svl4hIWlz+niYSlO6ikE5UXkN1JrRvIP2ut0A==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "prettier": ">=2.0",
+        "typescript": ">=2.9",
+        "vue-tsc": "^2.1.0"
+      },
+      "peerDependenciesMeta": {
+        "vue-tsc": {
+          "optional": true
+        }
       }
     },
     "node_modules/pretty-format": {

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "pdfjs-dist": "^5.1.91",
     "prettier": "^3.5.3",
     "prettier-eslint": "^16.3.0",
+    "prettier-plugin-organize-imports": "^4.1.0",
     "typescript": "~5.8.3",
     "typescript-eslint": "8.29.0"
   }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:headless": "ng test --watch=false --browsers=ChromeHeadless",
     "test:coverage": "ng test --watch=false --browsers=ChromeHeadless --code-coverage",
     "lint": "ng lint",
-    "format": "prettier --check \"{./*,src/**}.{js,json,ts,html,css,scss}\" \"./public/site.webmanifest\"",
+    "format": "prettier --check \"{./*,src/**/*}.{js,json,ts,html,css,scss}\" \"./public/site.webmanifest\"",
     "format:fix": "npm run format -- --write",
     "spell": "codespell src/",
     "spell:fix": "codespell -w -i 3 src/",

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -4,8 +4,8 @@ import { PreloadAllModules, provideRouter, withPreloading } from '@angular/route
 import { MAT_SNACK_BAR_DEFAULT_OPTIONS } from '@angular/material/snack-bar';
 import { provideClientHydration, withIncrementalHydration } from '@angular/platform-browser';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
-import { ROUTES } from './app.routes';
 import { provideServiceWorker } from '@angular/service-worker';
+import { ROUTES } from './app.routes';
 
 export const APP_CONFIG: ApplicationConfig = {
   providers: [

--- a/src/app/checklists/checklists.component.html
+++ b/src/app/checklists/checklists.component.html
@@ -12,16 +12,7 @@
           (downloadFile)="onDownloadFile($event)"
           (deleteFile)="onDeleteFile()"
           (fileInfo)="onFileInfo()"
-          [downloadFormats]="[
-            { id: 'ace', name: 'Garmin G3X/GTN [.ace]' },
-            { id: 'dynon', name: 'Dynon - no wrapping [.txt]' },
-            { id: 'dynon31', name: 'Dynon - 40% / 31 columns [.txt]' },
-            { id: 'dynon40', name: 'Dynon - 50% / 40 columns [.txt]' },
-            { id: 'afs', name: 'Advanced Flight Systems [.afd]' },
-            { id: 'grt', name: 'GRT [.txt]' },
-            { id: 'fmd', name: 'ForeFlight [.fmd]' },
-            { id: 'json', name: 'Raw data [.json]' },
-          ]"
+          [downloadFormats]="_downloadFormats"
         />
         <checklist-file-picker
           [selectedFile]="selectedFile?.metadata?.name ?? ''"

--- a/src/app/checklists/checklists.component.html
+++ b/src/app/checklists/checklists.component.html
@@ -12,7 +12,6 @@
           (downloadFile)="onDownloadFile($event)"
           (deleteFile)="onDeleteFile()"
           (fileInfo)="onFileInfo()"
-          [downloadFormats]="_downloadFormats"
         />
         <checklist-file-picker
           [selectedFile]="selectedFile?.metadata?.name ?? ''"

--- a/src/app/checklists/checklists.component.ts
+++ b/src/app/checklists/checklists.component.ts
@@ -26,7 +26,7 @@ import {
   ChecklistItem_Type,
 } from '../../../gen/ts/checklist';
 import { FormatId } from '../../model/formats/format-id';
-import { FORMAT_REGISTRY, serializeChecklistFile } from '../../model/formats/format-registry';
+import { serializeChecklistFile } from '../../model/formats/format-registry';
 import { ChecklistStorage } from '../../model/storage/checklist-storage';
 import { GoogleDriveStorage } from '../../model/storage/gdrive';
 import { PreferenceStorage } from '../../model/storage/preference-storage';
@@ -65,8 +65,6 @@ interface ParsedFragment {
   styleUrl: './checklists.component.scss',
 })
 export class ChecklistsComponent implements OnInit, AfterViewInit, OnDestroy, HotkeyRegistree {
-  protected readonly _downloadFormats = FORMAT_REGISTRY.getSupportedOutputFormats();
-
   static readonly NEW_ITEM_SHORTCUTS = [
     { secondKey: 'r', typeDescription: 'challenge/response', type: ChecklistItem_Type.ITEM_CHALLENGE_RESPONSE },
     { secondKey: 'c', typeDescription: 'challenge', type: ChecklistItem_Type.ITEM_CHALLENGE },

--- a/src/app/checklists/command-bar/command-bar.component.html
+++ b/src/app/checklists/command-bar/command-bar.component.html
@@ -26,7 +26,7 @@
   <mat-menu #downloadMenu>
     @for (format of downloadFormats; track format.id) {
       <button mat-menu-item [attr.aria-label]="'Download as ' + format.name" (click)="downloadFile.emit(format.id)">
-        {{ format.name }} [.{{ format.extension }}]
+        {{ format.name }} [{{ format.extension }}]
       </button>
     }
   </mat-menu>

--- a/src/app/checklists/command-bar/command-bar.component.html
+++ b/src/app/checklists/command-bar/command-bar.component.html
@@ -24,14 +24,11 @@
     <mat-icon>download</mat-icon>
   </button>
   <mat-menu #downloadMenu>
-    <button
-      mat-menu-item
-      *ngFor="let format of downloadFormats()"
-      [attr.aria-label]="'Download as ' + format.name"
-      (click)="downloadFile.emit(format.id)"
-    >
-      {{ format.name }}
-    </button>
+    @for (format of downloadFormats; track format.id) {
+      <button mat-menu-item [attr.aria-label]="'Download as ' + format.name" (click)="downloadFile.emit(format.id)">
+        {{ format.name }} [.{{ format.extension }}]
+      </button>
+    }
   </mat-menu>
   <button
     mat-icon-button

--- a/src/app/checklists/command-bar/command-bar.component.html
+++ b/src/app/checklists/command-bar/command-bar.component.html
@@ -38,7 +38,7 @@
     matTooltip="Print file"
     aria-label="Print file"
     [disabled]="!fileIsOpen()"
-    (click)="downloadFile.emit('pdf')"
+    (click)="downloadFile.emit(_formatIdPdf)"
   >
     <mat-icon>print</mat-icon>
   </button>

--- a/src/app/checklists/command-bar/command-bar.component.spec.ts
+++ b/src/app/checklists/command-bar/command-bar.component.spec.ts
@@ -4,11 +4,14 @@ import { MatDialogHarness } from '@angular/material/dialog/testing';
 import { MatMenuHarness } from '@angular/material/menu/testing';
 import { render, screen } from '@testing-library/angular';
 import userEvent, { UserEvent } from '@testing-library/user-event';
-import { ChecklistCommandBarComponent, DownloadFormat } from './command-bar.component';
+import { ChecklistCommandBarComponent } from './command-bar.component';
 
-const DOWNLOAD_FORMATS: DownloadFormat[] = [
-  { id: 'foo', name: 'Foobar' },
-  { id: 'baz', name: 'Baz' },
+import { OutputFormat } from '../../../model/formats/abstract-format';
+import { FormatId } from '../../../model/formats/format-id';
+
+const DOWNLOAD_FORMATS: OutputFormat[] = [
+  { id: FormatId.ACE, name: 'Foobar', description: 'Foo bar format', supportsImport: true, extension: FormatId.ACE },
+  { id: FormatId.DYNON, name: 'Baz', description: 'Baz format', supportsImport: true, extension: FormatId.DYNON },
 ];
 
 describe('ChecklistCommandBarComponent', () => {
@@ -149,7 +152,7 @@ describe('ChecklistCommandBarComponent', () => {
     expect(formatButton).toBeVisible();
     await user.click(formatButton);
 
-    expect(downloadFile).toHaveBeenCalledOnceWith('foo');
+    expect(downloadFile).toHaveBeenCalledOnceWith(FormatId.ACE);
   });
 
   it('should emit when Delete is clicked', async () => {

--- a/src/app/checklists/command-bar/command-bar.component.spec.ts
+++ b/src/app/checklists/command-bar/command-bar.component.spec.ts
@@ -6,13 +6,7 @@ import { render, screen } from '@testing-library/angular';
 import userEvent, { UserEvent } from '@testing-library/user-event';
 import { ChecklistCommandBarComponent } from './command-bar.component';
 
-import { OutputFormat } from '../../../model/formats/abstract-format';
 import { FormatId } from '../../../model/formats/format-id';
-
-const DOWNLOAD_FORMATS: OutputFormat[] = [
-  { id: FormatId.ACE, name: 'Foobar', description: 'Foo bar format', supportsImport: true, extension: FormatId.ACE },
-  { id: FormatId.DYNON, name: 'Baz', description: 'Baz format', supportsImport: true, extension: FormatId.DYNON },
-];
 
 describe('ChecklistCommandBarComponent', () => {
   let loader: HarnessLoader;
@@ -44,7 +38,7 @@ describe('ChecklistCommandBarComponent', () => {
 
   async function renderComponent(hasFiles: boolean, fileIsOpen: boolean) {
     const { fixture } = await render(ChecklistCommandBarComponent, {
-      inputs: { hasFiles: hasFiles, fileIsOpen: fileIsOpen, downloadFormats: DOWNLOAD_FORMATS },
+      inputs: { hasFiles: hasFiles, fileIsOpen: fileIsOpen },
       on: { newFile, openFile, uploadFile, downloadFile, deleteFile, fileInfo },
     });
 
@@ -148,11 +142,11 @@ describe('ChecklistCommandBarComponent', () => {
     const menu = await loader.getHarness(MatMenuHarness.with({ triggerText: 'download' }));
     expect(await menu.isOpen()).toBeTrue();
 
-    const formatButton = await screen.findByRole('menuitem', { name: 'Download as Foobar' });
+    const formatButton = await screen.findByRole('menuitem', { name: 'Download as Boeing ForeFlight' });
     expect(formatButton).toBeVisible();
     await user.click(formatButton);
 
-    expect(downloadFile).toHaveBeenCalledOnceWith(FormatId.ACE);
+    expect(downloadFile).toHaveBeenCalledOnceWith(FormatId.FOREFLIGHT);
   });
 
   it('should emit when Delete is clicked', async () => {

--- a/src/app/checklists/command-bar/command-bar.component.ts
+++ b/src/app/checklists/command-bar/command-bar.component.ts
@@ -1,4 +1,3 @@
-import { NgFor } from '@angular/common';
 import { Component, input, output } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
@@ -8,21 +7,21 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 import { DeleteDialogComponent } from '../dialogs/delete-dialog/delete-dialog.component';
 import { TitleDialogComponent } from '../dialogs/title-dialog/title-dialog.component';
 
-import { OutputFormat } from '../../../model/formats/abstract-format';
 import { FormatId } from '../../../model/formats/format-id';
+import { FORMAT_REGISTRY } from '../../../model/formats/format-registry';
 
 @Component({
   selector: 'checklist-command-bar',
-  imports: [MatButtonModule, MatDialogModule, MatIconModule, MatMenuModule, MatTooltipModule, NgFor],
+  imports: [MatButtonModule, MatDialogModule, MatIconModule, MatMenuModule, MatTooltipModule],
   templateUrl: './command-bar.component.html',
   styleUrl: './command-bar.component.scss',
 })
 export class ChecklistCommandBarComponent {
   protected readonly _formatIdPdf = FormatId.PDF;
+  readonly downloadFormats = FORMAT_REGISTRY.getSupportedOutputFormats();
 
   readonly hasFiles = input.required<boolean>();
   readonly fileIsOpen = input.required<boolean>();
-  readonly downloadFormats = input.required<OutputFormat[]>();
   readonly newFile = output<string>(); // Emits filename
   readonly openFile = output<boolean>();
   readonly uploadFile = output<boolean>();

--- a/src/app/checklists/command-bar/command-bar.component.ts
+++ b/src/app/checklists/command-bar/command-bar.component.ts
@@ -8,10 +8,8 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 import { DeleteDialogComponent } from '../dialogs/delete-dialog/delete-dialog.component';
 import { TitleDialogComponent } from '../dialogs/title-dialog/title-dialog.component';
 
-export interface DownloadFormat {
-  id: string;
-  name: string;
-}
+import { OutputFormat } from '../../../model/formats/abstract-format';
+import { FormatId } from '../../../model/formats/format-id';
 
 @Component({
   selector: 'checklist-command-bar',
@@ -20,13 +18,15 @@ export interface DownloadFormat {
   styleUrl: './command-bar.component.scss',
 })
 export class ChecklistCommandBarComponent {
+  protected readonly _formatIdPdf = FormatId.PDF;
+
   readonly hasFiles = input.required<boolean>();
   readonly fileIsOpen = input.required<boolean>();
-  readonly downloadFormats = input.required<DownloadFormat[]>();
+  readonly downloadFormats = input.required<OutputFormat[]>();
   readonly newFile = output<string>(); // Emits filename
   readonly openFile = output<boolean>();
   readonly uploadFile = output<boolean>();
-  readonly downloadFile = output<string>();
+  readonly downloadFile = output<FormatId>();
   readonly deleteFile = output<boolean>();
   readonly fileInfo = output<boolean>();
 

--- a/src/app/checklists/command-bar/command-bar.component.ts
+++ b/src/app/checklists/command-bar/command-bar.component.ts
@@ -31,13 +31,6 @@ export class ChecklistCommandBarComponent {
 
   constructor(private readonly _dialog: MatDialog) {}
 
-  isValidFileName(name: string): string | undefined {
-    if (!name) {
-      return 'A name must be provided!';
-    }
-    return undefined;
-  }
-
   async onNewFile() {
     const title = await TitleDialogComponent.promptForTitle({ promptType: 'file' }, this._dialog);
     if (title) {

--- a/src/app/checklists/dialogs/print-dialog/print-dialog.component.spec.ts
+++ b/src/app/checklists/dialogs/print-dialog/print-dialog.component.spec.ts
@@ -1,15 +1,15 @@
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { Component, output } from '@angular/core';
+import { ComponentFixture, inject } from '@angular/core/testing';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { MatDialogHarness } from '@angular/material/dialog/testing';
 import { render, screen } from '@testing-library/angular';
 import userEvent, { UserEvent } from '@testing-library/user-event';
 import { DEFAULT_OPTIONS, PdfWriterOptions } from '../../../../model/formats/pdf-writer';
-import { PrintDialogComponent } from './print-dialog.component';
-import { PreferenceStorage } from '../../../../model/storage/preference-storage';
 import { LazyBrowserStorage } from '../../../../model/storage/browser-storage';
-import { ComponentFixture, inject } from '@angular/core/testing';
+import { PreferenceStorage } from '../../../../model/storage/preference-storage';
+import { PrintDialogComponent } from './print-dialog.component';
 
 @Component({
   standalone: true,

--- a/src/app/checklists/file-upload/file-upload.component.html
+++ b/src/app/checklists/file-upload/file-upload.component.html
@@ -1,7 +1,7 @@
 <div class="file-upload">
   <ngx-file-drop
     #drop
-    accept=".ace, .txt, .afd, .json, .fmd"
+    [accept]="_acceptExtensions"
     [directory]="false"
     [multiple]="false"
     [showBrowseBtn]="false"

--- a/src/app/checklists/file-upload/file-upload.component.ts
+++ b/src/app/checklists/file-upload/file-upload.component.ts
@@ -3,12 +3,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { NgxFileDropEntry, NgxFileDropModule } from 'ngx-file-drop';
 import { ChecklistFile } from '../../../../gen/ts/checklist';
-import { AceFormat } from '../../../model/formats/ace-format';
-import { DynonFormat } from '../../../model/formats/dynon-format';
-import { FormatError } from '../../../model/formats/error';
-import { ForeFlightFormat } from '../../../model/formats/foreflight-format';
-import { GrtFormat } from '../../../model/formats/grt-format';
-import { JsonFormat } from '../../../model/formats/json-format';
+import { FORMAT_REGISTRY, parseChecklistFile } from '../../../model/formats/format-registry';
 
 @Component({
   selector: 'checklist-file-upload',
@@ -18,6 +13,7 @@ import { JsonFormat } from '../../../model/formats/json-format';
 })
 export class ChecklistFileUploadComponent {
   readonly fileUploaded = output<ChecklistFile>();
+  protected readonly _acceptExtensions = FORMAT_REGISTRY.getSupportedInputExtensions();
 
   constructor(private readonly _snackBar: MatSnackBar) {}
 
@@ -33,7 +29,7 @@ export class ChecklistFileUploadComponent {
       .map(
         async (filePromise: Promise<File>): Promise<void> =>
           filePromise
-            .then(async (file: File): Promise<ChecklistFile> => this._parseFile(file))
+            .then(async (file: File): Promise<ChecklistFile> => parseChecklistFile(file))
             .then((checklistFile: ChecklistFile) => {
               this.fileUploaded.emit(checklistFile);
               return void 0;
@@ -44,22 +40,5 @@ export class ChecklistFileUploadComponent {
             }),
       );
     return Promise.all(parsedFiles);
-  }
-
-  private async _parseFile(file: File): Promise<ChecklistFile> {
-    const extension = file.name.slice(file.name.lastIndexOf('.') + 1).toLowerCase();
-    if (extension === 'fmd') {
-      return ForeFlightFormat.toProto(file);
-    } else if (extension === 'ace') {
-      return AceFormat.toProto(file);
-    } else if (extension === 'txt') {
-      return Promise.any([GrtFormat.toProto(file), DynonFormat.toProto(file)]);
-    } else if (extension === 'afd') {
-      return DynonFormat.toProto(file);
-    } else if (extension === 'json') {
-      return JsonFormat.toProto(file);
-    } else {
-      throw new FormatError(`Unknown file extension "${extension}".`);
-    }
   }
 }

--- a/src/app/nav/nav.component.spec.ts
+++ b/src/app/nav/nav.component.spec.ts
@@ -1,16 +1,16 @@
 import { ComponentFixture } from '@angular/core/testing';
 
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { MatDialogHarness } from '@angular/material/dialog/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { HotkeysService } from '@ngneat/hotkeys';
 import { render, RenderResult, screen, within } from '@testing-library/angular';
 import userEvent, { UserEvent } from '@testing-library/user-event';
+import { HelpComponent } from '../shared/hotkeys/help/help.component';
 import { NavData } from './nav-data';
 import { NavComponent } from './nav.component';
-import { HotkeysService } from '@ngneat/hotkeys';
-import { HelpComponent } from '../shared/hotkeys/help/help.component';
-import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { HarnessLoader } from '@angular/cdk/testing';
-import { MatDialogHarness } from '@angular/material/dialog/testing';
-import { MatDialog, MatDialogModule } from '@angular/material/dialog';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('NavComponent', () => {
   let user: UserEvent;

--- a/src/app/shared/hotkeys/help/help.component.spec.ts
+++ b/src/app/shared/hotkeys/help/help.component.spec.ts
@@ -4,8 +4,8 @@ import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { MatDialog, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { MatDialogHarness } from '@angular/material/dialog/testing';
-import { HelpComponent } from './help.component';
 import { firstValueFrom } from 'rxjs';
+import { HelpComponent } from './help.component';
 
 describe('HelpComponent', () => {
   let fixture: ComponentFixture<HelpComponent>;

--- a/src/app/welcome/welcome.component.html
+++ b/src/app/welcome/welcome.component.html
@@ -28,7 +28,7 @@
         <ul>
           @for (format of _formatRegistry.getSupportedOutputFormats(); track format.id) {
             <li>
-              {{ format.description }} (.{{ format.extension }})
+              {{ format.name }} ({{ format.extension }})
               @if (!format.supportsImport) {
                 - export only
               }

--- a/src/app/welcome/welcome.component.html
+++ b/src/app/welcome/welcome.component.html
@@ -13,7 +13,7 @@
     <mat-card class="filetype-card">
       <mat-card-header>
         <mat-card-title>Checklists</mat-card-title>
-        <mat-card-subtitle>(e.g .ace, .txt, .afd, .fmd)</mat-card-subtitle>
+        <mat-card-subtitle>(e.g {{ _formatRegistry.getSupportedInputExtensions() }})</mat-card-subtitle>
       </mat-card-header>
 
       <mat-card-content>
@@ -26,12 +26,14 @@
         </p>
         <p>Currently supported import/export formats:</p>
         <ul>
-          <li>Garmin G3X&trade;/GTN&trade; (.ace)</li>
-          <li>Dynon SkyView&trade; - multiple width options (.txt)</li>
-          <li>Advanced Flight Systems (.afd)</li>
-          <li>Grand Rapids Technology (.txt)</li>
-          <li>Boeing ForeFlight (.fmd)</li>
-          <li>Printable (.pdf) - export only</li>
+          @for (format of _formatRegistry.getSupportedOutputFormats(); track format.id) {
+            <li>
+              {{ format.description }} (.{{ format.extension }})
+              @if (!format.supportsImport) {
+                - export only
+              }
+            </li>
+          }
         </ul>
         <p>Not all avionics systems support all the features of this editor.</p>
       </mat-card-content>

--- a/src/app/welcome/welcome.component.ts
+++ b/src/app/welcome/welcome.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { RouterLink } from '@angular/router';
+import { FORMAT_REGISTRY } from '../../model/formats/format-registry';
 
 @Component({
   selector: 'app-welcome',
@@ -9,4 +10,6 @@ import { RouterLink } from '@angular/router';
   templateUrl: './welcome.component.html',
   styleUrl: './welcome.component.scss',
 })
-export class WelcomeComponent {}
+export class WelcomeComponent {
+  protected readonly _formatRegistry = FORMAT_REGISTRY;
+}

--- a/src/model/formats/abstract-format.ts
+++ b/src/model/formats/abstract-format.ts
@@ -1,10 +1,15 @@
 import { ChecklistFile } from '../../../gen/ts/checklist';
 import { FormatId } from './format-id';
 
-export type FileExtension = string;
+// https://github.com/microsoft/TypeScript/issues/44268
+function toLowerCase<T extends string>(str: T) {
+  return str.toLowerCase() as Lowercase<T>;
+}
+
+export type FileExtension = `.${Lowercase<string>}`;
 
 export function getFileExtension(fileName: string): FileExtension {
-  return fileName.slice(fileName.lastIndexOf('.') + 1).toLowerCase();
+  return `.${toLowerCase(fileName.slice(fileName.lastIndexOf('.') + 1))}`;
 }
 
 export interface FormatOptions {
@@ -34,7 +39,7 @@ export abstract class AbstractChecklistFormat<T extends FormatOptions = FormatOp
   }
 
   public get extension(): FileExtension {
-    return this._extension ?? this._formatId;
+    return this._extension ?? `.${this._formatId}`;
   }
 
   public abstract toProto(file: File): Promise<ChecklistFile>;

--- a/src/model/formats/abstract-format.ts
+++ b/src/model/formats/abstract-format.ts
@@ -1,0 +1,51 @@
+import { ChecklistFile } from '../../../gen/ts/checklist';
+import { FormatId } from './format-id';
+
+export type FileExtension = string;
+
+export function getFileExtension(fileName: string): FileExtension {
+  return fileName.slice(fileName.lastIndexOf('.') + 1).toLowerCase();
+}
+
+export interface FormatOptions {
+  supportsImport?: boolean;
+  extension?: FileExtension;
+}
+
+export type FormatConstructor<T extends FormatOptions> = new (
+  formatId: FormatId,
+  name: string,
+  args?: FormatOptions,
+) => AbstractChecklistFormat<T>;
+
+export abstract class ExportOptions {}
+
+export abstract class AbstractChecklistFormat<T extends FormatOptions = FormatOptions> {
+  public readonly supportsImport: boolean;
+  protected readonly _extension?: FileExtension;
+
+  constructor(
+    private readonly _formatId: FormatId,
+    public readonly name: string,
+    args?: T,
+  ) {
+    this.supportsImport = args?.supportsImport ?? true;
+    this._extension = args?.extension;
+  }
+
+  public get extension(): FileExtension {
+    return this._extension ?? this._formatId;
+  }
+
+  public abstract toProto(file: File): Promise<ChecklistFile>;
+
+  public abstract fromProto(file: ChecklistFile, options?: ExportOptions): Promise<File>;
+}
+
+export interface OutputFormat {
+  id: FormatId;
+  name: string;
+  description: string;
+  supportsImport: boolean;
+  extension: FileExtension;
+}

--- a/src/model/formats/abstract-format.ts
+++ b/src/model/formats/abstract-format.ts
@@ -45,7 +45,6 @@ export abstract class AbstractChecklistFormat<T extends FormatOptions = FormatOp
 export interface OutputFormat {
   id: FormatId;
   name: string;
-  description: string;
   supportsImport: boolean;
   extension: FileExtension;
 }

--- a/src/model/formats/ace-format.ts
+++ b/src/model/formats/ace-format.ts
@@ -10,6 +10,6 @@ export class AceFormat extends AbstractChecklistFormat {
 
   public async fromProto(file: ChecklistFile): Promise<File> {
     const blob = await new AceWriter().write(file);
-    return new File([blob], `${file.metadata!.name}.${this.extension}`);
+    return new File([blob], `${file.metadata!.name}${this.extension}`);
   }
 }

--- a/src/model/formats/ace-format.ts
+++ b/src/model/formats/ace-format.ts
@@ -1,14 +1,15 @@
 import { ChecklistFile } from '../../../gen/ts/checklist';
 import { AceReader } from './ace-reader';
 import { AceWriter } from './ace-writer';
+import { AbstractChecklistFormat } from './abstract-format';
 
-export class AceFormat {
-  public static async toProto(file: File): Promise<ChecklistFile> {
+export class AceFormat extends AbstractChecklistFormat {
+  public async toProto(file: File): Promise<ChecklistFile> {
     return new AceReader(file).read();
   }
 
-  public static async fromProto(file: ChecklistFile): Promise<File> {
+  public async fromProto(file: ChecklistFile): Promise<File> {
     const blob = await new AceWriter().write(file);
-    return new File([blob], file.metadata!.name + '.ace');
+    return new File([blob], `${file.metadata!.name}.${this.extension}`);
   }
 }

--- a/src/model/formats/ace-format.ts
+++ b/src/model/formats/ace-format.ts
@@ -1,7 +1,7 @@
 import { ChecklistFile } from '../../../gen/ts/checklist';
+import { AbstractChecklistFormat } from './abstract-format';
 import { AceReader } from './ace-reader';
 import { AceWriter } from './ace-writer';
-import { AbstractChecklistFormat } from './abstract-format';
 
 export class AceFormat extends AbstractChecklistFormat {
   public async toProto(file: File): Promise<ChecklistFile> {

--- a/src/model/formats/ace-reader.ts
+++ b/src/model/formats/ace-reader.ts
@@ -11,6 +11,7 @@ import {
 } from '../../../gen/ts/checklist';
 import * as AceConstants from './ace-constants';
 import { FormatError } from './error';
+import { FormatId } from './format-id';
 
 export class AceReader {
   private static readonly ENCODING = 'latin1'; // equivalent to ISO-8859-1
@@ -42,7 +43,7 @@ export class AceReader {
     let name = this._readLine();
     if (!name) {
       name = this._file.name;
-      if (name.toLowerCase().endsWith('.ace') && name.length > 4) {
+      if (name.toLowerCase().endsWith(`.${FormatId.ACE}`) && name.length > 4) {
         name = name.slice(0, -4);
       }
     }

--- a/src/model/formats/dynon-format.spec.ts
+++ b/src/model/formats/dynon-format.spec.ts
@@ -4,7 +4,7 @@ import { EXPECTED_CONTENTS } from './test-data';
 import { loadFile } from './test-utils';
 import { TextReader } from './text-reader';
 import { TextWriter } from './text-writer';
-import { FORMAT_REGISTRY } from './format-registry';
+import { FORMAT_REGISTRY, parseChecklistFile } from './format-registry';
 
 export const DYNON_EXPECTED_CONTENTS = new TextReader(new File([], 'fake'), DYNON_FORMAT_OPTIONS).testCaseify(
   EXPECTED_CONTENTS,
@@ -30,10 +30,8 @@ describe('DynonFormat', () => {
   });
 
   async function testWriteRead(fileName: string, formatId: FormatId): Promise<void> {
-    const readFormat = FORMAT_REGISTRY.getFormat(FormatId.DYNON);
-
     const f = await loadFile('/model/formats/' + fileName, 'test.txt');
-    const readFile = await readFormat.toProto(f);
+    const readFile = await parseChecklistFile(f);
     expect(readFile).toEqual(DYNON_EXPECTED_CONTENTS);
 
     // Now write the file back.

--- a/src/model/formats/dynon-format.spec.ts
+++ b/src/model/formats/dynon-format.spec.ts
@@ -1,10 +1,10 @@
 import { DYNON_FORMAT_OPTIONS } from './dynon-format';
 import { FormatId } from './format-id';
+import { FORMAT_REGISTRY, parseChecklistFile } from './format-registry';
 import { EXPECTED_CONTENTS } from './test-data';
 import { loadFile } from './test-utils';
 import { TextReader } from './text-reader';
 import { TextWriter } from './text-writer';
-import { FORMAT_REGISTRY, parseChecklistFile } from './format-registry';
 
 export const DYNON_EXPECTED_CONTENTS = new TextReader(new File([], 'fake'), DYNON_FORMAT_OPTIONS).testCaseify(
   EXPECTED_CONTENTS,

--- a/src/model/formats/dynon-format.spec.ts
+++ b/src/model/formats/dynon-format.spec.ts
@@ -1,8 +1,10 @@
-import { DYNON_FORMAT_OPTIONS, DynonFormat } from './dynon-format';
+import { DYNON_FORMAT_OPTIONS } from './dynon-format';
+import { FormatId } from './format-id';
 import { EXPECTED_CONTENTS } from './test-data';
 import { loadFile } from './test-utils';
 import { TextReader } from './text-reader';
 import { TextWriter } from './text-writer';
+import { FORMAT_REGISTRY } from './format-registry';
 
 export const DYNON_EXPECTED_CONTENTS = new TextReader(new File([], 'fake'), DYNON_FORMAT_OPTIONS).testCaseify(
   EXPECTED_CONTENTS,
@@ -15,26 +17,29 @@ describe('DynonFormat', () => {
 
   describe('read then write back test file', () => {
     it('with no wrapping', async () => {
-      await testWriteRead('test-dynon.txt');
+      await testWriteRead('test-dynon.txt', FormatId.DYNON);
     });
 
     it('with 31-column wrapping', async () => {
-      await testWriteRead('test-dynon31.txt', 31);
+      await testWriteRead('test-dynon31.txt', FormatId.DYNON31);
     });
 
     it('with 40-column wrapping', async () => {
-      await testWriteRead('test-dynon40.txt', 40);
+      await testWriteRead('test-dynon40.txt', FormatId.DYNON40);
     });
   });
 
-  async function testWriteRead(fileName: string, maxLineLength?: number) {
+  async function testWriteRead(fileName: string, formatId: FormatId): Promise<void> {
+    const readFormat = FORMAT_REGISTRY.getFormat(FormatId.DYNON);
+
     const f = await loadFile('/model/formats/' + fileName, 'test.txt');
-    const readFile = await DynonFormat.toProto(f);
+    const readFile = await readFormat.toProto(f);
     expect(readFile).toEqual(DYNON_EXPECTED_CONTENTS);
 
     // Now write the file back.
     const decoder = new TextDecoder('UTF-8');
-    const writtenFile = DynonFormat.fromProto(readFile, 'foo.txt', maxLineLength);
+    const writeFormat = FORMAT_REGISTRY.getFormat(formatId);
+    const writtenFile = await writeFormat.fromProto(readFile);
     const writtenData = decoder.decode(await writtenFile.arrayBuffer());
     const writtenLines = writtenData.split('\r\n');
     const readData = decoder.decode(await f.arrayBuffer());

--- a/src/model/formats/dynon-format.ts
+++ b/src/model/formats/dynon-format.ts
@@ -43,7 +43,7 @@ export class DynonFormat extends AbstractChecklistFormat<DynonFormatOptions> {
     this._textFormatOptions = Object.assign({}, DYNON_FORMAT_OPTIONS);
     this._textFormatOptions.maxLineLength = args?.maxLineLength;
     this._textFormatOptions.fileExtensions = [this.extension];
-    this._fileName = args?.fileName ?? `checklist.${this.extension}`;
+    this._fileName = args?.fileName ?? `checklist${this.extension}`;
   }
 
   public override get extension(): FileExtension {

--- a/src/model/formats/foreflight-format.spec.ts
+++ b/src/model/formats/foreflight-format.spec.ts
@@ -44,7 +44,7 @@ describe('ForeFlightFormat', () => {
 
   describe('ForeFlightReader', () => {
     it('should determine correct checklist metadata', () => {
-      const mockFile = new File([], `bar.${ForeFlightUtils.FILE_EXTENSION}`);
+      const mockFile = new File([], 'bar.fmd');
       expect(ForeFlightReader.getChecklistMetadata(mockFile, ForeFlightChecklistMetadata.create())).toEqual(
         ChecklistFileMetadata.create({ name: 'bar' }),
       );

--- a/src/model/formats/foreflight-format.ts
+++ b/src/model/formats/foreflight-format.ts
@@ -43,6 +43,6 @@ export class ForeFlightFormat extends AbstractChecklistFormat {
 
   public async fromProto(file: ChecklistFile): Promise<File> {
     const blob = await ForeFlightWriter.write(file);
-    return new File([blob], `${file.metadata!.name}.${this.extension}`);
+    return new File([blob], `${file.metadata!.name}${this.extension}`);
   }
 }

--- a/src/model/formats/foreflight-format.ts
+++ b/src/model/formats/foreflight-format.ts
@@ -2,8 +2,9 @@ import { ChecklistFile } from '../../../gen/ts/checklist';
 
 import { FormatError } from './error';
 import { ForeFlightReader } from './foreflight-reader';
-import { ForeFlightUtils } from './foreflight-utils';
 import { ForeFlightWriter } from './foreflight-writer';
+
+import { AbstractChecklistFormat } from './abstract-format';
 
 export class ForeFlightFormatError extends FormatError {
   constructor(message: string, cause?: Error) {
@@ -35,13 +36,13 @@ export class ForeFlightFormatError extends FormatError {
  *
  *   Multiline ForeFlight notes are expanded as multiple indented text elements.
  */
-export class ForeFlightFormat {
-  public static async toProto(file: File): Promise<ChecklistFile> {
+export class ForeFlightFormat extends AbstractChecklistFormat {
+  public async toProto(file: File): Promise<ChecklistFile> {
     return ForeFlightReader.read(file);
   }
 
-  public static async fromProto(file: ChecklistFile): Promise<File> {
+  public async fromProto(file: ChecklistFile): Promise<File> {
     const blob = await ForeFlightWriter.write(file);
-    return new File([blob], `${file.metadata!.name}.${ForeFlightUtils.FILE_EXTENSION}`);
+    return new File([blob], `${file.metadata!.name}.${this.extension}`);
   }
 }

--- a/src/model/formats/foreflight-reader.ts
+++ b/src/model/formats/foreflight-reader.ts
@@ -17,6 +17,7 @@ import {
 } from '../../../gen/ts/foreflight';
 import { ForeFlightFormatError } from './foreflight-format';
 import { ForeFlightUtils } from './foreflight-utils';
+import { FormatId } from './format-id';
 
 export class ForeFlightReader {
   public static async read(file: File): Promise<ChecklistFile> {
@@ -46,7 +47,7 @@ export class ForeFlightReader {
   public static getChecklistMetadata(file: File, metadata: ForeFlightChecklistMetadata): ChecklistFileMetadata {
     return ChecklistFileMetadata.create({
       // eslint-disable-next-line  @typescript-eslint/prefer-nullish-coalescing
-      name: metadata.name || file.name.replace(new RegExp(`\\.${ForeFlightUtils.FILE_EXTENSION}$`), ''),
+      name: metadata.name || file.name.replace(new RegExp(`\\.${FormatId.FOREFLIGHT}$`), ''),
       aircraftInfo: metadata.tailNumber,
       makeAndModel: metadata.detail,
     });

--- a/src/model/formats/foreflight-utils.ts
+++ b/src/model/formats/foreflight-utils.ts
@@ -12,8 +12,6 @@ function swap<T1, T2>([a, b]: [T1, T2]): [T2, T1] {
 }
 
 export class ForeFlightUtils {
-  public static readonly FILE_EXTENSION = 'fmd';
-
   public static readonly CONTAINER_TYPE = 'checklist';
   public static readonly SCHEMA_VERSION = '1.0';
 

--- a/src/model/formats/format-id.ts
+++ b/src/model/formats/format-id.ts
@@ -1,0 +1,11 @@
+export const enum FormatId {
+  ACE = 'ace',
+  AFD = 'afd',
+  DYNON = 'dynon',
+  DYNON31 = 'dynon31',
+  DYNON40 = 'dynon40',
+  FOREFLIGHT = 'fmd',
+  GRT = 'grt',
+  JSON = 'json',
+  PDF = 'pdf',
+}

--- a/src/model/formats/format-registry.ts
+++ b/src/model/formats/format-registry.ts
@@ -1,0 +1,119 @@
+import { ChecklistFile } from '../../../gen/ts/checklist';
+import {
+  AbstractChecklistFormat,
+  ExportOptions,
+  FileExtension,
+  FormatConstructor,
+  FormatOptions,
+  getFileExtension,
+  OutputFormat,
+} from './abstract-format';
+import { AceFormat } from './ace-format';
+import { DynonFormat, DynonFormatOptions } from './dynon-format';
+import { FormatError } from './error';
+import { ForeFlightFormat } from './foreflight-format';
+import { FormatId } from './format-id';
+import { GrtFormat } from './grt-format';
+import { JsonFormat } from './json-format';
+import { PdfFormat } from './pdf-format';
+import { TXT_EXTENSION } from './text-format-options';
+
+class FormatRegistry {
+  private readonly _outputFormats = new Map<FormatId, AbstractChecklistFormat>();
+  private readonly _inputFormats = new Map<FileExtension, AbstractChecklistFormat[]>();
+
+  public register<T extends FormatOptions>(
+    constructor: FormatConstructor<T>,
+    formatId: FormatId,
+    name: string,
+    args?: T,
+  ): void {
+    if (this._outputFormats.has(formatId)) {
+      throw new Error(`Format "${formatId}" already registered`);
+    }
+
+    const format = new constructor(formatId, name, args);
+    this._outputFormats.set(formatId, format);
+
+    if (format.supportsImport) {
+      const registeredFormats = this._inputFormats.get(format.extension);
+      if (registeredFormats) {
+        registeredFormats.push(format);
+      } else {
+        this._inputFormats.set(format.extension, [format]);
+      }
+    }
+  }
+
+  public getFormat(formatId: FormatId): AbstractChecklistFormat {
+    const format = this._outputFormats.get(formatId);
+    if (!format) {
+      throw new Error(`Format '${formatId}' not registered`);
+    }
+    return format;
+  }
+
+  public getFormatsByExtension(extension: string): AbstractChecklistFormat[] {
+    return this._inputFormats.get(extension) ?? [];
+  }
+
+  public getSupportedInputExtensions(): string {
+    return [...this._inputFormats.keys()]
+      .sort()
+      .map((item) => `.${item}`)
+      .join(', ');
+  }
+
+  public getSupportedOutputFormats(): OutputFormat[] {
+    return [...this._outputFormats.entries()].map(
+      ([formatId, format]): OutputFormat => ({
+        id: formatId,
+        name: format.name,
+        description: `${format.name} [.${format.extension}]`,
+        extension: format.extension,
+        supportsImport: format.supportsImport,
+      }),
+    );
+  }
+}
+
+export const FORMAT_REGISTRY = new FormatRegistry();
+
+FORMAT_REGISTRY.register(AceFormat, FormatId.ACE, 'Garmin G3X™/GTN™');
+FORMAT_REGISTRY.register(DynonFormat, FormatId.AFD, 'Advanced Flight Systems', {
+  extension: FormatId.AFD,
+  fileName: 'CHKLST.AFD',
+});
+FORMAT_REGISTRY.register(DynonFormat, FormatId.DYNON, 'Dynon SkyView™ - no wrap');
+FORMAT_REGISTRY.register<DynonFormatOptions>(DynonFormat, FormatId.DYNON31, 'Dynon SkyView™ - 40% / 31 cols.', {
+  maxLineLength: 31,
+});
+FORMAT_REGISTRY.register<DynonFormatOptions>(DynonFormat, FormatId.DYNON40, 'Dynon SkyView™ - 50% / 40 cols.', {
+  maxLineLength: 40,
+});
+FORMAT_REGISTRY.register(ForeFlightFormat, FormatId.FOREFLIGHT, 'Boeing ForeFlight');
+FORMAT_REGISTRY.register(GrtFormat, FormatId.GRT, 'Grand Rapids Technologies', {
+  supportsImport: true,
+  extension: TXT_EXTENSION,
+});
+FORMAT_REGISTRY.register(JsonFormat, FormatId.JSON, 'Raw data');
+FORMAT_REGISTRY.register(PdfFormat, FormatId.PDF, 'Printable PDF', { supportsImport: false });
+
+export async function serializeChecklistFile(
+  checklistFile: ChecklistFile,
+  formatId: FormatId,
+  options?: ExportOptions,
+): Promise<File> {
+  return FORMAT_REGISTRY.getFormat(formatId).fromProto(checklistFile, options);
+}
+
+export async function parseChecklistFile(file: File): Promise<ChecklistFile> {
+  const extension = getFileExtension(file.name);
+  const formats = FORMAT_REGISTRY.getFormatsByExtension(extension);
+
+  if (!formats.length) {
+    return Promise.reject(new FormatError(`Unknown file extension "${extension}".`));
+  }
+
+  return Promise.any(formats.map(async (format) => format.toProto(file)));
+}

--- a/src/model/formats/format-registry.ts
+++ b/src/model/formats/format-registry.ts
@@ -69,7 +69,6 @@ class FormatRegistry {
       ([formatId, format]): OutputFormat => ({
         id: formatId,
         name: format.name,
-        description: `${format.name} [.${format.extension}]`,
         extension: format.extension,
         supportsImport: format.supportsImport,
       }),

--- a/src/model/formats/format-registry.ts
+++ b/src/model/formats/format-registry.ts
@@ -53,15 +53,12 @@ class FormatRegistry {
     return format;
   }
 
-  public getFormatsByExtension(extension: string): AbstractChecklistFormat[] {
+  public getFormatsByExtension(extension: FileExtension): AbstractChecklistFormat[] {
     return this._inputFormats.get(extension) ?? [];
   }
 
   public getSupportedInputExtensions(): string {
-    return [...this._inputFormats.keys()]
-      .sort()
-      .map((item) => `.${item}`)
-      .join(', ');
+    return [...this._inputFormats.keys()].sort().join(', ');
   }
 
   public getSupportedOutputFormats(): OutputFormat[] {
@@ -79,8 +76,7 @@ class FormatRegistry {
 export const FORMAT_REGISTRY = new FormatRegistry();
 
 FORMAT_REGISTRY.register(AceFormat, FormatId.ACE, 'Garmin G3X™/GTN™');
-FORMAT_REGISTRY.register(DynonFormat, FormatId.AFD, 'Advanced Flight Systems', {
-  extension: FormatId.AFD,
+FORMAT_REGISTRY.register<DynonFormatOptions>(DynonFormat, FormatId.AFD, 'Advanced Flight Systems', {
   fileName: 'CHKLST.AFD',
 });
 FORMAT_REGISTRY.register(DynonFormat, FormatId.DYNON, 'Dynon SkyView™ - no wrap');

--- a/src/model/formats/grt-format.spec.ts
+++ b/src/model/formats/grt-format.spec.ts
@@ -4,7 +4,7 @@ import { EXPECTED_CONTENTS } from './test-data';
 import { loadFile } from './test-utils';
 import { TextReader } from './text-reader';
 import { TextWriter } from './text-writer';
-import { FORMAT_REGISTRY } from './format-registry';
+import { FORMAT_REGISTRY, parseChecklistFile } from './format-registry';
 
 export const GRT_EXPECTED_CONTENTS = new TextReader(new File([], 'fake'), GRT_FORMAT_OPTIONS).testCaseify(
   EXPECTED_CONTENTS,
@@ -18,7 +18,7 @@ describe('GrtFormat', () => {
   it('read then write back test file', async () => {
     // Read file and check the proto contents.
     const f = await loadFile('/model/formats/test-grt.txt', 'test.txt');
-    const readFile = await FORMAT_REGISTRY.getFormat(FormatId.GRT).toProto(f);
+    const readFile = await parseChecklistFile(f);
     expect(readFile).toEqual(GRT_EXPECTED_CONTENTS);
 
     // Now write the file back.

--- a/src/model/formats/grt-format.spec.ts
+++ b/src/model/formats/grt-format.spec.ts
@@ -1,8 +1,10 @@
-import { GRT_FORMAT_OPTIONS, GrtFormat } from './grt-format';
+import { FormatId } from './format-id';
+import { GRT_FORMAT_OPTIONS } from './grt-format';
 import { EXPECTED_CONTENTS } from './test-data';
 import { loadFile } from './test-utils';
 import { TextReader } from './text-reader';
 import { TextWriter } from './text-writer';
+import { FORMAT_REGISTRY } from './format-registry';
 
 export const GRT_EXPECTED_CONTENTS = new TextReader(new File([], 'fake'), GRT_FORMAT_OPTIONS).testCaseify(
   EXPECTED_CONTENTS,
@@ -16,12 +18,12 @@ describe('GrtFormat', () => {
   it('read then write back test file', async () => {
     // Read file and check the proto contents.
     const f = await loadFile('/model/formats/test-grt.txt', 'test.txt');
-    const readFile = await GrtFormat.toProto(f);
+    const readFile = await FORMAT_REGISTRY.getFormat(FormatId.GRT).toProto(f);
     expect(readFile).toEqual(GRT_EXPECTED_CONTENTS);
 
     // Now write the file back.
     const decoder = new TextDecoder('UTF-8');
-    const writtenFile = GrtFormat.fromProto(readFile);
+    const writtenFile = await FORMAT_REGISTRY.getFormat(FormatId.GRT).fromProto(readFile);
     const writtenData = decoder.decode(await writtenFile.arrayBuffer());
     const writtenLines = writtenData.split('\r\n');
     const readData = decoder.decode(await f.arrayBuffer());

--- a/src/model/formats/grt-format.spec.ts
+++ b/src/model/formats/grt-format.spec.ts
@@ -1,10 +1,10 @@
 import { FormatId } from './format-id';
+import { FORMAT_REGISTRY, parseChecklistFile } from './format-registry';
 import { GRT_FORMAT_OPTIONS } from './grt-format';
 import { EXPECTED_CONTENTS } from './test-data';
 import { loadFile } from './test-utils';
 import { TextReader } from './text-reader';
 import { TextWriter } from './text-writer';
-import { FORMAT_REGISTRY, parseChecklistFile } from './format-registry';
 
 export const GRT_EXPECTED_CONTENTS = new TextReader(new File([], 'fake'), GRT_FORMAT_OPTIONS).testCaseify(
   EXPECTED_CONTENTS,

--- a/src/model/formats/grt-format.ts
+++ b/src/model/formats/grt-format.ts
@@ -5,7 +5,7 @@ import { TextWriter } from './text-writer';
 import { AbstractChecklistFormat } from './abstract-format';
 
 export const GRT_FORMAT_OPTIONS: TextFormatOptions = {
-  fileExtensions: [`.${TXT_EXTENSION}`],
+  fileExtensions: [TXT_EXTENSION],
   indentWidth: 2,
 
   checklistPrefix: 'LIST',
@@ -30,6 +30,6 @@ export class GrtFormat extends AbstractChecklistFormat {
 
   public async fromProto(file: ChecklistFile): Promise<File> {
     const blob = new TextWriter(GRT_FORMAT_OPTIONS).write(file);
-    return Promise.resolve(new File([blob], `checklist.${TXT_EXTENSION}`));
+    return Promise.resolve(new File([blob], `checklist${TXT_EXTENSION}`));
   }
 }

--- a/src/model/formats/grt-format.ts
+++ b/src/model/formats/grt-format.ts
@@ -1,10 +1,11 @@
 import { ChecklistFile } from '../../../gen/ts/checklist';
-import { TextFormatOptions } from './text-format-options';
+import { TXT_EXTENSION, TextFormatOptions } from './text-format-options';
 import { TextReader } from './text-reader';
 import { TextWriter } from './text-writer';
+import { AbstractChecklistFormat } from './abstract-format';
 
 export const GRT_FORMAT_OPTIONS: TextFormatOptions = {
-  fileExtensions: ['.txt'],
+  fileExtensions: [`.${TXT_EXTENSION}`],
   indentWidth: 2,
 
   checklistPrefix: 'LIST',
@@ -22,13 +23,13 @@ export const GRT_FORMAT_OPTIONS: TextFormatOptions = {
   outputMetadata: true,
 };
 
-export class GrtFormat {
-  public static async toProto(file: File): Promise<ChecklistFile> {
+export class GrtFormat extends AbstractChecklistFormat {
+  public async toProto(file: File): Promise<ChecklistFile> {
     return new TextReader(file, GRT_FORMAT_OPTIONS).read();
   }
 
-  public static fromProto(file: ChecklistFile): File {
+  public async fromProto(file: ChecklistFile): Promise<File> {
     const blob = new TextWriter(GRT_FORMAT_OPTIONS).write(file);
-    return new File([blob], 'checklist.txt');
+    return Promise.resolve(new File([blob], `checklist.${TXT_EXTENSION}`));
   }
 }

--- a/src/model/formats/grt-format.ts
+++ b/src/model/formats/grt-format.ts
@@ -1,8 +1,8 @@
 import { ChecklistFile } from '../../../gen/ts/checklist';
+import { AbstractChecklistFormat } from './abstract-format';
 import { TXT_EXTENSION, TextFormatOptions } from './text-format-options';
 import { TextReader } from './text-reader';
 import { TextWriter } from './text-writer';
-import { AbstractChecklistFormat } from './abstract-format';
 
 export const GRT_FORMAT_OPTIONS: TextFormatOptions = {
   fileExtensions: [TXT_EXTENSION],

--- a/src/model/formats/json-format.spec.ts
+++ b/src/model/formats/json-format.spec.ts
@@ -1,11 +1,11 @@
-import { JsonFormat } from './json-format';
 import { EXPECTED_CONTENTS } from './test-data';
 import { loadFile } from './test-utils';
+import { FORMAT_REGISTRY } from './format-registry';
 
 describe('JsonFormat', () => {
   it('read test file', async () => {
     const f = await loadFile('/model/formats/test.json', 'test.json');
-    const readFile = await JsonFormat.toProto(f);
+    const readFile = await FORMAT_REGISTRY.getFormat(FormatId.JSON).toProto(f);
     expect(readFile).toEqual(EXPECTED_CONTENTS);
   });
 });

--- a/src/model/formats/json-format.spec.ts
+++ b/src/model/formats/json-format.spec.ts
@@ -1,6 +1,6 @@
+import { parseChecklistFile } from './format-registry';
 import { EXPECTED_CONTENTS } from './test-data';
 import { loadFile } from './test-utils';
-import { parseChecklistFile } from './format-registry';
 
 describe('JsonFormat', () => {
   it('read test file', async () => {

--- a/src/model/formats/json-format.spec.ts
+++ b/src/model/formats/json-format.spec.ts
@@ -1,11 +1,11 @@
 import { EXPECTED_CONTENTS } from './test-data';
 import { loadFile } from './test-utils';
-import { FORMAT_REGISTRY } from './format-registry';
+import { parseChecklistFile } from './format-registry';
 
 describe('JsonFormat', () => {
   it('read test file', async () => {
     const f = await loadFile('/model/formats/test.json', 'test.json');
-    const readFile = await FORMAT_REGISTRY.getFormat(FormatId.JSON).toProto(f);
+    const readFile = await parseChecklistFile(f);
     expect(readFile).toEqual(EXPECTED_CONTENTS);
   });
 });

--- a/src/model/formats/json-format.ts
+++ b/src/model/formats/json-format.ts
@@ -15,6 +15,6 @@ export class JsonFormat extends AbstractChecklistFormat {
 
   public async fromProto(file: ChecklistFile): Promise<File> {
     const contents = ChecklistFile.toJsonString(file, { prettySpaces: 2 });
-    return Promise.resolve(new File([contents], `${file.metadata!.name}.${this.extension}`));
+    return Promise.resolve(new File([contents], `${file.metadata!.name}${this.extension}`));
   }
 }

--- a/src/model/formats/json-format.ts
+++ b/src/model/formats/json-format.ts
@@ -1,7 +1,8 @@
 import { ChecklistFile, ChecklistGroup, ChecklistGroup_Category } from '../../../gen/ts/checklist';
+import { AbstractChecklistFormat } from './abstract-format';
 
-export class JsonFormat {
-  public static async toProto(file: File): Promise<ChecklistFile> {
+export class JsonFormat extends AbstractChecklistFormat {
+  public async toProto(file: File): Promise<ChecklistFile> {
     const contents = await file.text();
     const checklist = ChecklistFile.fromJsonString(contents);
     checklist.groups.forEach((group: ChecklistGroup) => {
@@ -12,8 +13,8 @@ export class JsonFormat {
     return checklist;
   }
 
-  public static fromProto(file: ChecklistFile): File {
+  public async fromProto(file: ChecklistFile): Promise<File> {
     const contents = ChecklistFile.toJsonString(file, { prettySpaces: 2 });
-    return new File([contents], file.metadata!.name + '.json');
+    return Promise.resolve(new File([contents], `${file.metadata!.name}.${this.extension}`));
   }
 }

--- a/src/model/formats/pdf-format.ts
+++ b/src/model/formats/pdf-format.ts
@@ -5,7 +5,7 @@ import { AbstractChecklistFormat } from './abstract-format';
 export class PdfFormat extends AbstractChecklistFormat {
   public async fromProto(file: ChecklistFile, options: PdfWriterOptions): Promise<File> {
     const blob = await new PdfWriter(options).write(file);
-    return new File([blob], `${file.metadata!.name}.${this.extension}`);
+    return new File([blob], `${file.metadata!.name}${this.extension}`);
   }
 
   public async toProto(file: File): Promise<ChecklistFile> {

--- a/src/model/formats/pdf-format.ts
+++ b/src/model/formats/pdf-format.ts
@@ -1,9 +1,14 @@
 import { ChecklistFile } from '../../../gen/ts/checklist';
 import { PdfWriter, PdfWriterOptions } from './pdf-writer';
+import { AbstractChecklistFormat } from './abstract-format';
 
-export class PdfFormat {
-  public static async fromProto(file: ChecklistFile, options?: PdfWriterOptions): Promise<File> {
+export class PdfFormat extends AbstractChecklistFormat {
+  public async fromProto(file: ChecklistFile, options: PdfWriterOptions): Promise<File> {
     const blob = await new PdfWriter(options).write(file);
-    return new File([blob], file.metadata!.name + '.pdf');
+    return new File([blob], `${file.metadata!.name}.${this.extension}`);
+  }
+
+  public async toProto(file: File): Promise<ChecklistFile> {
+    return Promise.reject(new Error(`Parsing of ${file.name} not implemented!`));
   }
 }

--- a/src/model/formats/pdf-format.ts
+++ b/src/model/formats/pdf-format.ts
@@ -1,6 +1,6 @@
 import { ChecklistFile } from '../../../gen/ts/checklist';
-import { PdfWriter, PdfWriterOptions } from './pdf-writer';
 import { AbstractChecklistFormat } from './abstract-format';
+import { PdfWriter, PdfWriterOptions } from './pdf-writer';
 
 export class PdfFormat extends AbstractChecklistFormat {
   public async fromProto(file: ChecklistFile, options: PdfWriterOptions): Promise<File> {

--- a/src/model/formats/pdf-writer.ts
+++ b/src/model/formats/pdf-writer.ts
@@ -10,6 +10,7 @@ import {
   ChecklistItem,
   ChecklistItem_Type,
 } from '../../../gen/ts/checklist';
+import { ExportOptions } from './abstract-format';
 import { FormatError } from './error';
 
 type OrientationType = jsPDFOptions['orientation'];
@@ -23,7 +24,7 @@ interface CellPaddingInputStructured {
   left?: number;
 }
 
-export interface PdfWriterOptions {
+export interface PdfWriterOptions extends ExportOptions {
   orientation?: OrientationType;
 
   // Must be a valid page size string, or 'custom'.

--- a/src/model/formats/text-format-options.ts
+++ b/src/model/formats/text-format-options.ts
@@ -9,6 +9,8 @@ export const DEFAULT_FIRST_GROUP = 'Main group';
 export const HEADER_COMMENT = '# CHECKLIST EXPORTED FROM https://github.com/rdamazio/efis-editor/';
 export const LAST_UPDATED_FOOTER = 'Last updated ';
 
+export const TXT_EXTENSION = 'txt';
+
 export interface TextFormatOptions {
   // Extensions that this format can parse.
   fileExtensions: string[];

--- a/src/model/formats/text-format-options.ts
+++ b/src/model/formats/text-format-options.ts
@@ -1,3 +1,5 @@
+import { FileExtension } from './abstract-format';
+
 export const WRAP_PREFIX = '| ';
 export const METADATA_CHECKLIST_TITLE = 'Checklist Info';
 export const METADATA_FILE_TITLE = 'Checklist file:';
@@ -9,7 +11,7 @@ export const DEFAULT_FIRST_GROUP = 'Main group';
 export const HEADER_COMMENT = '# CHECKLIST EXPORTED FROM https://github.com/rdamazio/efis-editor/';
 export const LAST_UPDATED_FOOTER = 'Last updated ';
 
-export const TXT_EXTENSION = 'txt';
+export const TXT_EXTENSION: FileExtension = '.txt';
 
 export interface TextFormatOptions {
   // Extensions that this format can parse.


### PR DESCRIPTION
So, here's my refactoring, I hope you like it. In my opinion, it makes further work on formats much more enjoyable than otherwise. Have fun with it!

Resolves: #182

P.S. It was actually quite pleasant to work on the project again after you extended all those linters, formatters, test infra, etc. Fantastic!

## Goals

* Have a central definition of what a format implementation should look like
* Have all constants related to formats in one place (`format-registry.ts`)
* Allow symbolic searches on strings related to format support, such as extensions
* Have serialization and deserialization "ladders" in one place, and get rid of ladders
* Type everything as strongly as possible, benefit from enforcement by transpilers and tooling
* DRY things out (duplication in UI components triggers my mania)

## PsAQ (pre-emptively self-asked questions)

**Q:** What is this weird `declare global` thing?
**A:** It's a forward declaration for typing purposes.

**Q:** Can I just move everything to `format-registry.ts`?
**A:** No, this will cause recursive imports that the transpiler cannot resolve.

**Q:** Some formats now return Promises even though they don't have to.
**A:** Sorry, that's the price of interface unification.

**Q:** Formats now need to be instantiated, when most could be static.
**A:** True, but unfortunately there is no way to restrict interfaces for static classes in TypeScript. I tried to hack a combination of class decorator and static interfaces, but it's very problematic in many ways. So I gave up and went with the "normal" ABC with all its consequences.

**Q:** The `FormatOptions` constraints are repeated.
**A:** Yes, I don't know a way around it, but at least the consistency is enforced by the transpiler.

**Q:** Are you aware that PDF is now also offered for download?
**A:** Yes, I intentionally didn't exclude it, because I like it. I think it's nice to have both a separate button and a download option.

**Q:** Canceling the PDF dialog throws an exception.
**A:** Yes, that's how it was before me ;-)

**Q:** The second commit is too big, are you kidding?
**A:** It's _a lot of work_ to repackage it into atomic commits, and non-atomic has little value in my eyes.

**Q:** I don't like this stuff at all, you're a DRY nut.
**A:** I asked before I started ;-)

