### PR TITLE
fix(app): suppress NG0956 warning

### DIFF
--- a/src/app/checklists/file-picker/file-picker.component.html
+++ b/src/app/checklists/file-picker/file-picker.component.html
@@ -2,7 +2,8 @@
   <mat-form-field class="dropdown">
     <mat-label>Select checklist file</mat-label>
     <mat-select [(value)]="selectedFile" (selectionChange)="fileSelected.emit(selectedFile())">
-      @for (file of fileNames(); track file) {
+      {{ '' // opt-out of NG0956 warning regarding tracking by identity (non-static collection) }}
+      @for (file of fileNames(); track file + '') {
         <mat-option [value]="file">
           {{ file }}
         </mat-option>

--- a/src/app/checklists/items-list/items-list.component.html
+++ b/src/app/checklists/items-list/items-list.component.html
@@ -11,7 +11,7 @@
       [cdkDropListConnectedTo]="groupDropListIds()"
       (cdkDropListDropped)="onDrop($event)"
     >
-      @for (item of chklist.items; track item) {
+      @for (item of chklist.items; track _trackChecklistItem(item)) {
         <div class="list-item" cdkDrag [cdkDragData]="item" role="listitem" [attr.aria-label]="itemLabel(item)">
           <checklist-item
             #item

--- a/src/app/checklists/items-list/items-list.component.ts
+++ b/src/app/checklists/items-list/items-list.component.ts
@@ -253,4 +253,7 @@ export class ChecklistItemsComponent {
     }
     return `Item: ${item.prompt}`;
   }
+
+  // Opt-out of NG0956 warning regarding tracking by identity (non-static collection)
+  protected readonly _trackChecklistItem = (item: ChecklistItem) => item;
 }


### PR DESCRIPTION
I figured out where they come from, and it seems that the recommended way at the moment is to add a tracking method to suppress them if tracking by identity is desired for non-static collections:

https://github.com/angular/angular/issues/56471

I don't know if you want to take this, but I found it really annoying when working on the tests, hence this PR.