### PR TITLE
fix(model): supply AFS extension explicitly, default for Dynon is `.txt`

### DIFF
--- a/src/model/formats/format-registry.ts
+++ b/src/model/formats/format-registry.ts
@@ -77,6 +77,7 @@ export const FORMAT_REGISTRY = new FormatRegistry();
 
 FORMAT_REGISTRY.register(AceFormat, FormatId.ACE, 'Garmin G3X™/GTN™');
 FORMAT_REGISTRY.register<DynonFormatOptions>(DynonFormat, FormatId.AFD, 'Advanced Flight Systems', {
+  extension: `.${FormatId.AFD}`,
   fileName: 'CHKLST.AFD',
   maxLineLength: 96,
 });


### PR DESCRIPTION
Sorry, got a little fix after all the refactoring because I tricked myself with the inheritance stuff. The default for Dynon is TXT, so the AFS extension has to be provided explicitly.