### PR TITLE
Rename ForeFlight after Thoma Bravo transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ You can try it out directly in the link above, but here's what it currently look
 - Checklists:
   - Advanced Flight Systems (AFS)
   - Dynon SkyView
-  - ForeFlight (.fmd file format)<sup>†</sup>
+  - Jeppesen ForeFlight (.fmd file format)<sup>†</sup>
   - Garmin Pilot (.gplt file format) <sup>ᶢ†</sup>
   - Garmin G3X / G3X Touch / GTN (.ace file format)
   - Grand Rapids (GRT)

--- a/src/app/checklists/command-bar/command-bar.component.spec.ts
+++ b/src/app/checklists/command-bar/command-bar.component.spec.ts
@@ -144,7 +144,7 @@ describe('ChecklistCommandBarComponent', () => {
     const menu = await loader.getHarness(MatMenuHarness.with({ triggerText: 'download' }));
     expect(await menu.isOpen()).toBeTrue();
 
-    const formatButton = await screen.findByRole('menuitem', { name: 'Download as Boeing ForeFlight' });
+    const formatButton = await screen.findByRole('menuitem', { name: 'Download as Jeppesen ForeFlight' });
     expect(formatButton).toBeVisible();
     await user.click(formatButton);
 

--- a/src/model/formats/format-registry.ts
+++ b/src/model/formats/format-registry.ts
@@ -90,7 +90,7 @@ FORMAT_REGISTRY.register<DynonFormatOptions>(DynonFormat, FormatId.DYNON31, 'Dyn
 FORMAT_REGISTRY.register<DynonFormatOptions>(DynonFormat, FormatId.DYNON40, 'Dynon SkyView™ - 50% / 40 cols.', {
   maxLineLength: 40,
 });
-FORMAT_REGISTRY.register(ForeFlightFormat, FormatId.FOREFLIGHT, 'Boeing ForeFlight');
+FORMAT_REGISTRY.register(ForeFlightFormat, FormatId.FOREFLIGHT, 'Jeppesen ForeFlight');
 FORMAT_REGISTRY.register(GarminPilotFormat, FormatId.GARMIN_PILOT, 'Garmin Pilot™');
 FORMAT_REGISTRY.register(GrtFormat, FormatId.GRT, 'Grand Rapids Technologies', {
   supportsImport: true,


### PR DESCRIPTION
According to my understanding, this is what they want to be called now:

https://www.jeppesenforeflight.com/news/jeppesen-foreflight-launches-as-a-standalone-company-to-redefine-the-future-of-aviation-software

Alternatively, if you think it's not a good idea, we could remove the brand altogether.