### PR TITLE
fix(model): Avoid parsing copyright field into GarminPilotMetaData

### DIFF
--- a/src/model/formats/garmin-pilot-writer.ts
+++ b/src/model/formats/garmin-pilot-writer.ts
@@ -44,13 +44,15 @@ export class GarminPilotWriter {
     this._checklistItemsGarmin.length = 0;
 
     let metadata;
-
-    try {
-      metadata = GarminPilotMetadata.fromJsonString(file.metadata!.copyrightInfo);
-    } catch (e) {
-      console.warn('Unable to parse GarminPilotMetadata:', e);
-      metadata = GarminPilotMetadata.create({ sortOrder: 0 });
+    if (file.metadata?.copyrightInfo) {
+      // Attempt to parse copyrightInfo as GarminPilotMetadata only if it's present.
+      try {
+        metadata = GarminPilotMetadata.fromJsonString(file.metadata.copyrightInfo);
+      } catch (e) {
+        console.warn('Unable to parse GarminPilotMetadata:', e);
+      }
     }
+    metadata ??= GarminPilotMetadata.create({ sortOrder: 0 });
 
     file.groups.forEach((groupEFIS) => {
       this._checklistGroupToGarmin(groupEFIS);


### PR DESCRIPTION
Fixes #326 